### PR TITLE
chore: avoid decommissioning to finalize early

### DIFF
--- a/contracts/LiquidityOrchestrator.sol
+++ b/contracts/LiquidityOrchestrator.sol
@@ -936,11 +936,10 @@ contract LiquidityOrchestrator is
         vaultContract.updateVaultState(tokens, shares, finalTotalAssets);
 
         if (config.isDecommissioningVault(vaultAddress)) {
-            // Finalize only when all queued exits are drained and no non-underlying positions remain.
-            // Guards against premature finalization if the ZK circuit misbehaves or batches overflow.
-            bool queuesEmpty = vaultContract.pendingRedeem(1) == 0 && vaultContract.pendingDeposit(1) == 0;
+            // Finalize only when all queued requests are processed and no non-underlying positions remain open.
+            bool noRequests = vaultContract.pendingRedeemCount() == 0 && vaultContract.pendingDepositCount() == 0;
             bool portfolioLiquidated = tokens.length == 0;
-            if (queuesEmpty && portfolioLiquidated) {
+            if (noRequests && portfolioLiquidated) {
                 config.completeVaultDecommissioning(vaultAddress);
             }
         }

--- a/contracts/LiquidityOrchestrator.sol
+++ b/contracts/LiquidityOrchestrator.sol
@@ -936,7 +936,13 @@ contract LiquidityOrchestrator is
         vaultContract.updateVaultState(tokens, shares, finalTotalAssets);
 
         if (config.isDecommissioningVault(vaultAddress)) {
-            config.completeVaultDecommissioning(vaultAddress);
+            // Finalize only when all queued exits are drained and no non-underlying positions remain.
+            // Guards against premature finalization if the ZK circuit misbehaves or batches overflow.
+            bool queuesEmpty = vaultContract.pendingRedeem(1) == 0 && vaultContract.pendingDeposit(1) == 0;
+            bool portfolioLiquidated = tokens.length == 0;
+            if (queuesEmpty && portfolioLiquidated) {
+                config.completeVaultDecommissioning(vaultAddress);
+            }
         }
     }
 

--- a/contracts/LiquidityOrchestrator.sol
+++ b/contracts/LiquidityOrchestrator.sol
@@ -938,7 +938,7 @@ contract LiquidityOrchestrator is
         if (config.isDecommissioningVault(vaultAddress)) {
             // Finalize only when all queued requests are processed and no non-underlying positions remain open.
             bool noRequests = vaultContract.pendingRedeemCount() == 0 && vaultContract.pendingDepositCount() == 0;
-            bool portfolioLiquidated = tokens.length == 0;
+            bool portfolioLiquidated = tokens.length == 1;
             if (noRequests && portfolioLiquidated) {
                 config.completeVaultDecommissioning(vaultAddress);
             }
@@ -967,7 +967,7 @@ contract LiquidityOrchestrator is
     /// @dev Requires the caller to be the upgrade timelock (if set) or the owner (during initial
     ///      bootstrapping before a timelock has been configured).
     // solhint-disable-next-line use-natspec
-    function _authorizeUpgrade(address) internal override {
+    function _authorizeUpgrade(address) internal view override {
         if (upgradeTimelock != address(0)) {
             if (msg.sender != upgradeTimelock) revert ErrorsLib.NotAuthorized();
         } else {

--- a/contracts/interfaces/IOrionVault.sol
+++ b/contracts/interfaces/IOrionVault.sol
@@ -207,6 +207,14 @@ interface IOrionVault is IERC4626 {
     /// @dev This returns share amounts, not underlying asset amounts
     function pendingRedeem(uint256 fulfillBatchSize) external view returns (uint256);
 
+    /// @notice Get the number of pending deposit queue entries.
+    /// @return The number of unique users with non-zero pending deposit requests.
+    function pendingDepositCount() external view returns (uint256);
+
+    /// @notice Get the number of pending redeem queue entries.
+    /// @return The number of unique users with non-zero pending redeem requests.
+    function pendingRedeemCount() external view returns (uint256);
+
     /// @notice Get the list of pending redeem entries (users and shares) for the next fulfill batch
     /// @param fulfillBatchSize The maximum number of requests to consider
     /// @return users Addresses with pending redeem requests in batch order

--- a/contracts/vaults/OrionVault.sol
+++ b/contracts/vaults/OrionVault.sol
@@ -628,6 +628,16 @@ abstract contract OrionVault is Initializable, ERC4626Upgradeable, ReentrancyGua
     }
 
     /// @inheritdoc IOrionVault
+    function pendingDepositCount() external view returns (uint256) {
+        return _depositRequests.length();
+    }
+
+    /// @inheritdoc IOrionVault
+    function pendingRedeemCount() external view returns (uint256) {
+        return _redeemRequests.length();
+    }
+
+    /// @inheritdoc IOrionVault
     function pendingRedeemBatch(uint256 fulfillBatchSize) external view returns (address[] memory, uint256[] memory) {
         uint256 length = _redeemRequests.length();
         if (length == 0) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposed counts for pending deposit and redeem requests so pending queue sizes are visible.

* **Bug Fixes**
  * Improved vault decommissioning finalization to prevent premature completion. Decommissioning now only finalizes when all pending exit/deposit requests are drained and the vault’s non-underlying portfolio is empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->