### PR TITLE
fix: include buyingLegEntryBuffer and bufferAmount in protocol state hash

### DIFF
--- a/contracts/LiquidityOrchestrator.sol
+++ b/contracts/LiquidityOrchestrator.sol
@@ -629,7 +629,7 @@ contract LiquidityOrchestrator is
     /// @notice Builds the protocol state hash from static epoch parameters
     /// @return The protocol state hash
     function _buildProtocolStateHash() internal view returns (bytes32) {
-        bytes32 protocolStateHash = keccak256(
+        return keccak256(
             abi.encode(
                 _currentEpoch.activeVFeeCoefficient,
                 _currentEpoch.activeRsFeeCoefficient,
@@ -643,10 +643,12 @@ contract LiquidityOrchestrator is
                 config.riskFreeRate(),
                 config.decommissioningAssets(),
                 _failedEpochTokens,
-                initialEpochBufferAmount
+                initialEpochBufferAmount,
+                buyingLegEntryBuffer,
+                bufferAmount,
+                IERC20(underlyingAsset).balanceOf(address(this))
             )
         );
-        return protocolStateHash;
     }
 
     /// @notice Aggregates asset leaves using sequential folding

--- a/contracts/LiquidityOrchestrator.sol
+++ b/contracts/LiquidityOrchestrator.sol
@@ -478,11 +478,14 @@ contract LiquidityOrchestrator is
             StatesStruct memory states = _verifyPerformData(_publicValues, proofBytes, statesBytes);
 
             _processMinibatchSell(states.sellLeg);
+            // slither-disable-start reentrancy-no-eth
+            // Safe: performUpkeep is nonReentrant; buffer mutations are phase-gated (Idle-only deposit/withdraw).
             if (currentPhase == LiquidityUpkeepPhase.BuyingLeg) {
                 bufferAmount += states.bufferIncrease;
                 _pendingEpochProtocolFees = states.epochProtocolFees;
                 buyingLegEntryBuffer = bufferAmount;
             }
+            // slither-disable-end reentrancy-no-eth
         } else if (currentPhase == LiquidityUpkeepPhase.BuyingLeg) {
             StatesStruct memory states = _verifyPerformData(_publicValues, proofBytes, statesBytes);
             _processMinibatchBuy(states.buyLeg);
@@ -517,6 +520,7 @@ contract LiquidityOrchestrator is
     function _handleStart() internal {
         _buildVaultsEpoch();
 
+        // slither-disable-next-line incorrect-equality
         if (_currentEpoch.vaultsEpoch.length == 0) {
             // Defer the next upkeep by epoch duration
             _nextUpdateTime = block.timestamp + epochDuration;
@@ -606,6 +610,7 @@ contract LiquidityOrchestrator is
         _commitmentBatchIndex = i1;
 
         // All vault leaves processed, seal the commitment and advance phase
+        // slither-disable-next-line incorrect-equality
         if (i1 == vaultCount) {
             address[] memory assets = config.getAllWhitelistedAssets();
             uint256[] memory assetPrices = getAssetPrices(assets);
@@ -629,26 +634,27 @@ contract LiquidityOrchestrator is
     /// @notice Builds the protocol state hash from static epoch parameters
     /// @return The protocol state hash
     function _buildProtocolStateHash() internal view returns (bytes32) {
-        return keccak256(
-            abi.encode(
-                _currentEpoch.activeVFeeCoefficient,
-                _currentEpoch.activeRsFeeCoefficient,
-                config.maxFulfillBatchSize(),
-                targetBufferRatio,
-                config.priceAdapterDecimals(),
-                config.strategistIntentDecimals(),
-                epochDuration,
-                config.getAllWhitelistedAssets(),
-                config.getAllTokenDecimals(),
-                config.riskFreeRate(),
-                config.decommissioningAssets(),
-                _failedEpochTokens,
-                initialEpochBufferAmount,
-                buyingLegEntryBuffer,
-                bufferAmount,
-                IERC20(underlyingAsset).balanceOf(address(this))
-            )
-        );
+        return
+            keccak256(
+                abi.encode(
+                    _currentEpoch.activeVFeeCoefficient,
+                    _currentEpoch.activeRsFeeCoefficient,
+                    config.maxFulfillBatchSize(),
+                    targetBufferRatio,
+                    config.priceAdapterDecimals(),
+                    config.strategistIntentDecimals(),
+                    epochDuration,
+                    config.getAllWhitelistedAssets(),
+                    config.getAllTokenDecimals(),
+                    config.riskFreeRate(),
+                    config.decommissioningAssets(),
+                    _failedEpochTokens,
+                    initialEpochBufferAmount,
+                    buyingLegEntryBuffer,
+                    bufferAmount,
+                    IERC20(underlyingAsset).balanceOf(address(this))
+                )
+            );
     }
 
     /// @notice Aggregates asset leaves using sequential folding
@@ -906,6 +912,7 @@ contract LiquidityOrchestrator is
         uint16 i1 = i0 + minibatchSize;
         ++currentMinibatchIndex;
 
+        // slither-disable-next-line incorrect-equality
         if (i1 > vaultsEpoch.length || i1 == vaultsEpoch.length) {
             i1 = uint16(vaultsEpoch.length);
             currentPhase = LiquidityUpkeepPhase.Idle;
@@ -972,6 +979,7 @@ contract LiquidityOrchestrator is
 
         if (config.isDecommissioningVault(vaultAddress)) {
             // Finalize only when all queued requests are processed and no non-underlying positions remain open.
+            // slither-disable-next-line incorrect-equality
             bool noRequests = vaultContract.pendingRedeemCount() == 0 && vaultContract.pendingDepositCount() == 0;
             bool portfolioLiquidated =
                 (tokens.length == 0 && finalTotalAssets == 0) || (tokens.length == 1 && tokens[0] == underlyingAsset);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orion-finance/protocol",
   "description": "Orion Finance Protocol",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "type": "module",
   "engines": {
     "node": ">=22.13.0"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protocol state commitment accuracy by incorporating additional buffer details and the contract’s live underlying asset balance, strengthening validation during processing.

* **Chores**
  * Added static-analysis suppressions around relevant phase-gated and boundary logic sections (no functional change).

* **Release**
  * Updated the package version to **2.5.2**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->