### PR TITLE
refactor: resolve protocol admin solely via OrionConfig.owner

### DIFF
--- a/contracts/LiquidityOrchestrator.sol
+++ b/contracts/LiquidityOrchestrator.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.34;
 
-import "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import { ReentrancyGuardTransient } from "@openzeppelin/contracts/utils/ReentrancyGuardTransient.sol";
 import "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
@@ -9,6 +8,7 @@ import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
 import "./interfaces/ILiquidityOrchestrator.sol";
 import "./interfaces/IOrionConfig.sol";
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import "./interfaces/IPriceAdapterRegistry.sol";
 import "./libraries/EventsLib.sol";
 import "./interfaces/IOrionVault.sol";
@@ -34,7 +34,6 @@ import "@openzeppelin/contracts/utils/math/SafeCast.sol";
  */
 contract LiquidityOrchestrator is
     Initializable,
-    Ownable2StepUpgradeable,
     ReentrancyGuardTransient,
     PausableUpgradeable,
     UUPSUpgradeable,
@@ -167,9 +166,15 @@ contract LiquidityOrchestrator is
     /*                                MODIFIERS                                   */
     /* -------------------------------------------------------------------------- */
 
-    /// @dev Restricts function to only owner or automation registry
+    /// @dev Restricts function to protocol admin
+    modifier onlyAdmin() {
+        if (msg.sender != Ownable(address(config)).owner()) revert ErrorsLib.NotAuthorized();
+        _;
+    }
+
+    /// @dev Restricts function to protocol admin or automation registry
     modifier onlyAuthorizedTrigger() {
-        if (msg.sender != owner() && msg.sender != automationRegistry) {
+        if (msg.sender != Ownable(address(config)).owner() && msg.sender != automationRegistry) {
             revert ErrorsLib.NotAuthorized();
         }
         _;
@@ -181,9 +186,9 @@ contract LiquidityOrchestrator is
         _;
     }
 
-    /// @dev Restricts function to only owner or guardian
-    modifier onlyOwnerOrGuardian() {
-        if (msg.sender != owner() && msg.sender != config.guardian()) {
+    /// @dev Restricts function to protocol admin or guardian
+    modifier onlyAdminOrGuardian() {
+        if (msg.sender != Ownable(address(config)).owner() && msg.sender != config.guardian()) {
             revert ErrorsLib.NotAuthorized();
         }
         _;
@@ -204,26 +209,21 @@ contract LiquidityOrchestrator is
     }
 
     /// @notice Initializes the contract
-    /// @param initialOwner The address of the initial owner
     /// @param config_ The address of the OrionConfig contract
     /// @param automationRegistry_ The address of the Chainlink Automation Registry
     /// @param verifier_ The address of the SP1 verifier contract
     /// @param vKey_ The verification key for the Orion Internal State Orchestrator
     function initialize(
-        address initialOwner,
         address config_,
         address automationRegistry_,
         address verifier_,
         bytes32 vKey_
     ) public initializer {
-        if (initialOwner == address(0)) revert ErrorsLib.ZeroAddress();
         if (config_ == address(0)) revert ErrorsLib.ZeroAddress();
         if (automationRegistry_ == address(0)) revert ErrorsLib.ZeroAddress();
         if (verifier_ == address(0)) revert ErrorsLib.ZeroAddress();
         if (vKey_ == bytes32(0)) revert ErrorsLib.InvalidArguments();
 
-        __Ownable_init(initialOwner);
-        __Ownable2Step_init();
         __Pausable_init();
 
         config = IOrionConfig(config_);
@@ -246,11 +246,11 @@ contract LiquidityOrchestrator is
     }
 
     /* -------------------------------------------------------------------------- */
-    /*                                OWNER FUNCTIONS                             */
+    /*                                ADMIN FUNCTIONS                             */
     /* -------------------------------------------------------------------------- */
 
     /// @inheritdoc ILiquidityOrchestrator
-    function updateEpochDuration(uint32 newEpochDuration) external onlyOwnerOrGuardian {
+    function updateEpochDuration(uint32 newEpochDuration) external onlyAdminOrGuardian {
         if (newEpochDuration == 0) revert ErrorsLib.InvalidArguments();
         if (!config.isSystemIdle()) revert ErrorsLib.SystemNotIdle();
 
@@ -259,28 +259,28 @@ contract LiquidityOrchestrator is
     }
 
     /// @inheritdoc ILiquidityOrchestrator
-    function updateExecutionMinibatchSize(uint8 _executionMinibatchSize) external onlyOwner {
+    function updateExecutionMinibatchSize(uint8 _executionMinibatchSize) external onlyAdmin {
         if (_executionMinibatchSize == 0) revert ErrorsLib.InvalidArguments();
         if (!config.isSystemIdle()) revert ErrorsLib.SystemNotIdle();
         executionMinibatchSize = _executionMinibatchSize;
     }
 
     /// @inheritdoc ILiquidityOrchestrator
-    function updateMinibatchSize(uint8 _minibatchSize) external onlyOwner {
+    function updateMinibatchSize(uint8 _minibatchSize) external onlyAdmin {
         if (_minibatchSize == 0) revert ErrorsLib.InvalidArguments();
         if (!config.isSystemIdle()) revert ErrorsLib.SystemNotIdle();
         minibatchSize = _minibatchSize;
     }
 
     /// @inheritdoc ILiquidityOrchestrator
-    function updateCommitmentMinibatchSize(uint8 _commitmentMinibatchSize) external onlyOwner {
+    function updateCommitmentMinibatchSize(uint8 _commitmentMinibatchSize) external onlyAdmin {
         if (_commitmentMinibatchSize == 0) revert ErrorsLib.InvalidArguments();
         if (!config.isSystemIdle()) revert ErrorsLib.SystemNotIdle();
         commitmentMinibatchSize = _commitmentMinibatchSize;
     }
 
     /// @inheritdoc ILiquidityOrchestrator
-    function updateAutomationRegistry(address newAutomationRegistry) external onlyOwner {
+    function updateAutomationRegistry(address newAutomationRegistry) external onlyAdmin {
         if (newAutomationRegistry == address(0)) revert ErrorsLib.ZeroAddress();
 
         automationRegistry = newAutomationRegistry;
@@ -288,21 +288,21 @@ contract LiquidityOrchestrator is
     }
 
     /// @inheritdoc ILiquidityOrchestrator
-    function updateVerifier(address newVerifier) external onlyOwner {
+    function updateVerifier(address newVerifier) external onlyAdmin {
         if (newVerifier == address(0)) revert ErrorsLib.ZeroAddress();
         verifier = ISP1Verifier(newVerifier);
         emit EventsLib.SP1VerifierUpdated(newVerifier);
     }
 
     /// @inheritdoc ILiquidityOrchestrator
-    function updateVKey(bytes32 newvKey) external onlyOwner {
+    function updateVKey(bytes32 newvKey) external onlyAdmin {
         if (newvKey == bytes32(0)) revert ErrorsLib.InvalidArguments();
         vKey = newvKey;
         emit EventsLib.VKeyUpdated(newvKey);
     }
 
     /// @inheritdoc ILiquidityOrchestrator
-    function setTargetBufferRatio(uint256 _targetBufferRatio) external onlyOwner {
+    function setTargetBufferRatio(uint256 _targetBufferRatio) external onlyAdmin {
         if (_targetBufferRatio == 0) revert ErrorsLib.InvalidArguments();
         // 5%
         if (_targetBufferRatio > 500) revert ErrorsLib.InvalidArguments();
@@ -311,7 +311,7 @@ contract LiquidityOrchestrator is
     }
 
     /// @inheritdoc ILiquidityOrchestrator
-    function setSlippageTolerance(uint256 _slippageTolerance) external onlyOwner {
+    function setSlippageTolerance(uint256 _slippageTolerance) external onlyAdmin {
         if (_slippageTolerance > BASIS_POINTS_FACTOR) revert ErrorsLib.InvalidArguments();
         slippageTolerance = _slippageTolerance;
     }
@@ -331,7 +331,7 @@ contract LiquidityOrchestrator is
     }
 
     /// @inheritdoc ILiquidityOrchestrator
-    function withdrawLiquidity(uint256 amount) external onlyOwner {
+    function withdrawLiquidity(uint256 amount) external onlyAdmin {
         if (amount == 0) revert ErrorsLib.AmountMustBeGreaterThanZero(underlyingAsset);
         if (currentPhase != LiquidityUpkeepPhase.Idle) revert ErrorsLib.SystemNotIdle();
 
@@ -348,7 +348,7 @@ contract LiquidityOrchestrator is
     }
 
     /// @inheritdoc ILiquidityOrchestrator
-    function claimProtocolFees(uint256 amount) external onlyOwner {
+    function claimProtocolFees(uint256 amount) external onlyAdmin {
         if (amount == 0) revert ErrorsLib.AmountMustBeGreaterThanZero(underlyingAsset);
 
         if (amount > pendingProtocolFees) revert ErrorsLib.InsufficientAmount();
@@ -396,13 +396,13 @@ contract LiquidityOrchestrator is
     }
 
     /// @inheritdoc ILiquidityOrchestrator
-    function pause() external onlyOwnerOrGuardian {
+    function pause() external onlyAdminOrGuardian {
         _pause();
         emit EventsLib.ProtocolPaused(msg.sender);
     }
 
     /// @inheritdoc ILiquidityOrchestrator
-    function unpause() external onlyOwner {
+    function unpause() external onlyAdmin {
         _unpause();
         emit EventsLib.ProtocolUnpaused(msg.sender);
     }
@@ -1016,12 +1016,12 @@ contract LiquidityOrchestrator is
     }
 
     /// @notice Sets the upgrade timelock address.
-    /// @dev If no timelock is set yet, only the owner may call this. Once a timelock is active,
-    ///      only the timelock itself may replace it, preventing the owner from bypassing the delay.
+    /// @dev If no timelock is set yet, only the protocol admin may call this. Once a timelock is active,
+    ///      only the timelock itself may replace it, preventing the admin from bypassing the delay.
     /// @param newTimelock The new timelock address (e.g. OpenZeppelin TimelockController); address(0) not permitted
     function setUpgradeTimelock(address newTimelock) external {
         if (upgradeTimelock == address(0)) {
-            if (msg.sender != owner()) revert ErrorsLib.NotAuthorized();
+            if (msg.sender != Ownable(address(config)).owner()) revert ErrorsLib.NotAuthorized();
         } else {
             if (msg.sender != upgradeTimelock) revert ErrorsLib.NotAuthorized();
         }
@@ -1031,14 +1031,14 @@ contract LiquidityOrchestrator is
     }
 
     /// @notice Authorizes an upgrade to a new implementation
-    /// @dev Requires the caller to be the upgrade timelock (if set) or the owner (during initial
+    /// @dev Requires the caller to be the upgrade timelock (if set) or the protocol admin (during initial
     ///      bootstrapping before a timelock has been configured).
     // solhint-disable-next-line use-natspec
     function _authorizeUpgrade(address) internal view override {
         if (upgradeTimelock != address(0)) {
             if (msg.sender != upgradeTimelock) revert ErrorsLib.NotAuthorized();
         } else {
-            if (msg.sender != owner()) revert ErrorsLib.NotAuthorized();
+            if (msg.sender != Ownable(address(config)).owner()) revert ErrorsLib.NotAuthorized();
         }
     }
 

--- a/contracts/execution/UniswapV3ExecutionAdapter.sol
+++ b/contracts/execution/UniswapV3ExecutionAdapter.sol
@@ -9,8 +9,8 @@ import { IQuoterV2 } from "@uniswap/v3-periphery/contracts/interfaces/IQuoterV2.
 import { IUniswapV3Factory } from "@uniswap/v3-core/contracts/interfaces/IUniswapV3Factory.sol";
 import { IExecutionAdapter } from "../interfaces/IExecutionAdapter.sol";
 import { IOrionConfig } from "../interfaces/IOrionConfig.sol";
-import { ILiquidityOrchestrator } from "../interfaces/ILiquidityOrchestrator.sol";
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { ILiquidityOrchestrator } from "../interfaces/ILiquidityOrchestrator.sol";
 
 /**
  * @title UniswapV3ExecutionAdapter
@@ -47,7 +47,7 @@ contract UniswapV3ExecutionAdapter is IExecutionAdapter {
     mapping(address => uint24) public assetFee;
 
     /// @dev Restricts function to the protocol admin
-    modifier onlyConfigOwner() {
+    modifier onlyAdmin() {
         if (msg.sender != Ownable(address(CONFIG)).owner()) revert ErrorsLib.NotAuthorized();
         _;
     }
@@ -76,7 +76,7 @@ contract UniswapV3ExecutionAdapter is IExecutionAdapter {
     /// @notice Sets the fee tier for a given asset
     /// @param asset The address of the asset
     /// @param fee The fee tier to set
-    function setAssetFee(address asset, uint24 fee) external onlyConfigOwner {
+    function setAssetFee(address asset, uint24 fee) external onlyAdmin {
         if (asset == address(0)) revert ErrorsLib.ZeroAddress();
         if (!CONFIG.isSystemIdle()) revert ErrorsLib.SystemNotIdle();
 

--- a/contracts/factories/EncryptedVaultFactory.sol
+++ b/contracts/factories/EncryptedVaultFactory.sol
@@ -3,10 +3,10 @@ pragma solidity ^0.8.34;
 
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import "@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol";
 import "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
 import "../interfaces/IOrionConfig.sol";
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import { ErrorsLib } from "../libraries/ErrorsLib.sol";
 import { EventsLib } from "../libraries/EventsLib.sol";
 import { OrionEncryptedVault } from "../vaults/OrionEncryptedVault.sol";
@@ -18,7 +18,7 @@ import { OrionEncryptedVault } from "../vaults/OrionEncryptedVault.sol";
  * @dev This contract deploys BeaconProxy instances that point to a shared encrypted vault implementation.
  * @custom:security-contact security@orionfinance.ai
  */
-contract EncryptedVaultFactory is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable {
+contract EncryptedVaultFactory is Initializable, UUPSUpgradeable {
     /// @notice Orion Config contract address
     IOrionConfig public config;
 
@@ -28,6 +28,12 @@ contract EncryptedVaultFactory is Initializable, Ownable2StepUpgradeable, UUPSUp
     /// @notice Address of the upgrade timelock that must authorise all implementation upgrades
     address public upgradeTimelock;
 
+    /// @dev Restricts function to protocol admin
+    modifier onlyAdmin() {
+        if (msg.sender != Ownable(address(config)).owner()) revert ErrorsLib.NotAuthorized();
+        _;
+    }
+
     /// @notice Constructor that disables initializers for the implementation contract
     /// @custom:oz-upgrades-unsafe-allow constructor
     // solhint-disable-next-line use-natspec
@@ -36,15 +42,10 @@ contract EncryptedVaultFactory is Initializable, Ownable2StepUpgradeable, UUPSUp
     }
 
     /// @notice Initialize the contract
-    /// @param initialOwner The address of the initial owner
     /// @param configAddress The address of the OrionConfig contract
     /// @param vaultBeaconAddress The address of the UpgradeableBeacon for vaults
-    function initialize(address initialOwner, address configAddress, address vaultBeaconAddress) public initializer {
-        if (initialOwner == address(0)) revert ErrorsLib.ZeroAddress();
+    function initialize(address configAddress, address vaultBeaconAddress) public initializer {
         if (configAddress == address(0) || vaultBeaconAddress == address(0)) revert ErrorsLib.ZeroAddress();
-
-        __Ownable_init(initialOwner);
-        __Ownable2Step_init();
 
         config = IOrionConfig(configAddress);
         vaultBeacon = UpgradeableBeacon(vaultBeaconAddress);
@@ -121,19 +122,19 @@ contract EncryptedVaultFactory is Initializable, Ownable2StepUpgradeable, UUPSUp
 
     /// @notice Updates the vault beacon address
     /// @param newVaultBeacon The new UpgradeableBeacon address
-    function setVaultBeacon(address newVaultBeacon) external onlyOwner {
+    function setVaultBeacon(address newVaultBeacon) external onlyAdmin {
         if (newVaultBeacon == address(0)) revert ErrorsLib.ZeroAddress();
         vaultBeacon = UpgradeableBeacon(newVaultBeacon);
         emit EventsLib.VaultBeaconUpdated(newVaultBeacon);
     }
 
     /// @notice Sets the upgrade timelock address.
-    /// @dev If no timelock is set yet, only the owner may call this. Once a timelock is active,
-    ///      only the timelock itself may replace it, preventing the owner from bypassing the delay.
+    /// @dev If no timelock is set yet, only the protocol admin may call this. Once a timelock is active,
+    ///      only the timelock itself may replace it, preventing the admin from bypassing the delay.
     /// @param newTimelock The new timelock address (e.g. OpenZeppelin TimelockController); address(0) not permitted
     function setUpgradeTimelock(address newTimelock) external {
         if (upgradeTimelock == address(0)) {
-            if (msg.sender != owner()) revert ErrorsLib.NotAuthorized();
+            if (msg.sender != Ownable(address(config)).owner()) revert ErrorsLib.NotAuthorized();
         } else {
             if (msg.sender != upgradeTimelock) revert ErrorsLib.NotAuthorized();
         }
@@ -143,14 +144,14 @@ contract EncryptedVaultFactory is Initializable, Ownable2StepUpgradeable, UUPSUp
     }
 
     /// @notice Authorizes an upgrade to a new implementation
-    /// @dev Requires the caller to be the upgrade timelock (if set) or the owner (during initial
+    /// @dev Requires the caller to be the upgrade timelock (if set) or the protocol admin (during initial
     ///      bootstrapping before a timelock has been configured).
     // solhint-disable-next-line use-natspec
-    function _authorizeUpgrade(address) internal override {
+    function _authorizeUpgrade(address) internal view override {
         if (upgradeTimelock != address(0)) {
             if (msg.sender != upgradeTimelock) revert ErrorsLib.NotAuthorized();
         } else {
-            if (msg.sender != owner()) revert ErrorsLib.NotAuthorized();
+            if (msg.sender != Ownable(address(config)).owner()) revert ErrorsLib.NotAuthorized();
         }
     }
 

--- a/contracts/factories/TransparentVaultFactory.sol
+++ b/contracts/factories/TransparentVaultFactory.sol
@@ -3,10 +3,10 @@ pragma solidity ^0.8.34;
 
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import "@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol";
 import "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
 import "../interfaces/IOrionConfig.sol";
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import { ErrorsLib } from "../libraries/ErrorsLib.sol";
 import { EventsLib } from "../libraries/EventsLib.sol";
 import { OrionTransparentVault } from "../vaults/OrionTransparentVault.sol";
@@ -18,7 +18,7 @@ import { OrionTransparentVault } from "../vaults/OrionTransparentVault.sol";
  * @dev This contract deploys BeaconProxy instances that point to a shared transparent vault implementation.
  * @custom:security-contact security@orionfinance.ai
  */
-contract TransparentVaultFactory is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable {
+contract TransparentVaultFactory is Initializable, UUPSUpgradeable {
     /// @notice Orion Config contract address
     IOrionConfig public config;
 
@@ -28,6 +28,12 @@ contract TransparentVaultFactory is Initializable, Ownable2StepUpgradeable, UUPS
     /// @notice Address of the upgrade timelock that must authorise all implementation upgrades
     address public upgradeTimelock;
 
+    /// @dev Restricts function to protocol admin
+    modifier onlyAdmin() {
+        if (msg.sender != Ownable(address(config)).owner()) revert ErrorsLib.NotAuthorized();
+        _;
+    }
+
     /// @notice Constructor that disables initializers for the implementation contract
     /// @custom:oz-upgrades-unsafe-allow constructor
     // solhint-disable-next-line use-natspec
@@ -36,15 +42,10 @@ contract TransparentVaultFactory is Initializable, Ownable2StepUpgradeable, UUPS
     }
 
     /// @notice Initialize the contract
-    /// @param initialOwner The address of the initial owner
     /// @param configAddress The address of the OrionConfig contract
     /// @param vaultBeaconAddress The address of the UpgradeableBeacon for vaults
-    function initialize(address initialOwner, address configAddress, address vaultBeaconAddress) public initializer {
-        if (initialOwner == address(0)) revert ErrorsLib.ZeroAddress();
+    function initialize(address configAddress, address vaultBeaconAddress) public initializer {
         if (configAddress == address(0) || vaultBeaconAddress == address(0)) revert ErrorsLib.ZeroAddress();
-
-        __Ownable_init(initialOwner);
-        __Ownable2Step_init();
 
         config = IOrionConfig(configAddress);
         vaultBeacon = UpgradeableBeacon(vaultBeaconAddress);
@@ -119,19 +120,19 @@ contract TransparentVaultFactory is Initializable, Ownable2StepUpgradeable, UUPS
 
     /// @notice Updates the vault beacon address
     /// @param newVaultBeacon The new UpgradeableBeacon address
-    function setVaultBeacon(address newVaultBeacon) external onlyOwner {
+    function setVaultBeacon(address newVaultBeacon) external onlyAdmin {
         if (newVaultBeacon == address(0)) revert ErrorsLib.ZeroAddress();
         vaultBeacon = UpgradeableBeacon(newVaultBeacon);
         emit EventsLib.VaultBeaconUpdated(newVaultBeacon);
     }
 
     /// @notice Sets the upgrade timelock address.
-    /// @dev If no timelock is set yet, only the owner may call this. Once a timelock is active,
-    ///      only the timelock itself may replace it, preventing the owner from bypassing the delay.
+    /// @dev If no timelock is set yet, only the protocol admin may call this. Once a timelock is active,
+    ///      only the timelock itself may replace it, preventing the admin from bypassing the delay.
     /// @param newTimelock The new timelock address (e.g. OpenZeppelin TimelockController); address(0) not permitted
     function setUpgradeTimelock(address newTimelock) external {
         if (upgradeTimelock == address(0)) {
-            if (msg.sender != owner()) revert ErrorsLib.NotAuthorized();
+            if (msg.sender != Ownable(address(config)).owner()) revert ErrorsLib.NotAuthorized();
         } else {
             if (msg.sender != upgradeTimelock) revert ErrorsLib.NotAuthorized();
         }
@@ -141,14 +142,14 @@ contract TransparentVaultFactory is Initializable, Ownable2StepUpgradeable, UUPS
     }
 
     /// @notice Authorizes an upgrade to a new implementation
-    /// @dev Requires the caller to be the upgrade timelock (if set) or the owner (during initial
+    /// @dev Requires the caller to be the upgrade timelock (if set) or the protocol admin (during initial
     ///      bootstrapping before a timelock has been configured).
     // solhint-disable-next-line use-natspec
-    function _authorizeUpgrade(address) internal override {
+    function _authorizeUpgrade(address) internal view override {
         if (upgradeTimelock != address(0)) {
             if (msg.sender != upgradeTimelock) revert ErrorsLib.NotAuthorized();
         } else {
-            if (msg.sender != owner()) revert ErrorsLib.NotAuthorized();
+            if (msg.sender != Ownable(address(config)).owner()) revert ErrorsLib.NotAuthorized();
         }
     }
 

--- a/contracts/price/ChainlinkPriceAdapter.sol
+++ b/contracts/price/ChainlinkPriceAdapter.sol
@@ -2,9 +2,10 @@
 pragma solidity ^0.8.34;
 
 import { IPriceAdapter } from "../interfaces/IPriceAdapter.sol";
+import { IOrionConfig } from "../interfaces/IOrionConfig.sol";
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import { ErrorsLib } from "../libraries/ErrorsLib.sol";
 import { AggregatorV3Interface } from "@chainlink/contracts/src/v0.8/shared/interfaces/AggregatorV3Interface.sol";
-import "@openzeppelin/contracts/access/Ownable2Step.sol";
 import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 
 /**
@@ -16,7 +17,7 @@ import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
  *
  * @custom:security-contact security@orionfinance.ai
  */
-contract ChainlinkPriceAdapter is IPriceAdapter, Ownable2Step {
+contract ChainlinkPriceAdapter is IPriceAdapter {
     /**
      * @notice Per-asset feed configuration.
      * @param feed Chainlink base aggregator.
@@ -38,6 +39,9 @@ contract ChainlinkPriceAdapter is IPriceAdapter, Ownable2Step {
         uint256 scaleFactor;
     }
 
+    /// @notice Orion Config contract
+    IOrionConfig public immutable CONFIG;
+
     /// @notice Per-asset feed configuration store.
     mapping(address => FeedConfig) public feedConfigOf;
 
@@ -49,6 +53,12 @@ contract ChainlinkPriceAdapter is IPriceAdapter, Ownable2Step {
 
     /// @notice Precision of the cross-rate output when a quoteFeed is configured.
     uint8 public constant PRICE_DECIMALS = 18;
+
+    /// @dev Restricts function to protocol admin
+    modifier onlyAdmin() {
+        if (msg.sender != Ownable(address(CONFIG)).owner()) revert ErrorsLib.NotAuthorized();
+        _;
+    }
 
     /// @notice Emitted when a Chainlink feed is configured for an asset
     /// @param asset The asset address
@@ -73,7 +83,11 @@ contract ChainlinkPriceAdapter is IPriceAdapter, Ownable2Step {
     /// @param fallbackAdapter The fallback price adapter, or address(0) to disable.
     event FallbackAdapterSet(address indexed asset, address indexed fallbackAdapter);
 
-    constructor() Ownable(msg.sender) {}
+    /// @param configAddress OrionConfig contract address
+    constructor(address configAddress) {
+        if (configAddress == address(0)) revert ErrorsLib.ZeroAddress();
+        CONFIG = IOrionConfig(configAddress);
+    }
 
     /**
      * @notice Configure Chainlink feed for an asset.
@@ -96,7 +110,7 @@ contract ChainlinkPriceAdapter is IPriceAdapter, Ownable2Step {
         uint256 _minPrice,
         uint256 _maxPrice,
         address quoteFeed
-    ) external onlyOwner {
+    ) external onlyAdmin {
         if (asset == address(0) || feed == address(0)) revert ErrorsLib.ZeroAddress();
         if (_maxStaleness == 0) revert ErrorsLib.InvalidArguments();
         if (_maxPrice == 0) revert ErrorsLib.InvalidArguments();
@@ -140,7 +154,7 @@ contract ChainlinkPriceAdapter is IPriceAdapter, Ownable2Step {
     /// @dev Intended for UniswapV3PoolPriceAdapter. Other Chainlink validation errors still revert.
     /// @param asset The asset address.
     /// @param fallbackAdapter The fallback adapter, or address(0) to disable.
-    function setFallbackAdapter(address asset, IPriceAdapter fallbackAdapter) external onlyOwner {
+    function setFallbackAdapter(address asset, IPriceAdapter fallbackAdapter) external onlyAdmin {
         if (asset == address(0)) revert ErrorsLib.ZeroAddress();
         if (address(fallbackAdapter) == address(this)) revert ErrorsLib.InvalidArguments();
 

--- a/contracts/price/PriceAdapterRegistry.sol
+++ b/contracts/price/PriceAdapterRegistry.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.34;
 
-import "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "../interfaces/IPriceAdapterRegistry.sol";
@@ -10,6 +9,7 @@ import { ErrorsLib } from "../libraries/ErrorsLib.sol";
 import { EventsLib } from "../libraries/EventsLib.sol";
 import { UtilitiesLib } from "../libraries/UtilitiesLib.sol";
 import { IOrionConfig } from "../interfaces/IOrionConfig.sol";
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 
 /**
  * @title PriceAdapterRegistry
@@ -18,7 +18,7 @@ import { IOrionConfig } from "../interfaces/IOrionConfig.sol";
  * @dev This contract allows the configuration of price adapters for various assets in the investment universe.
  * @custom:security-contact security@orionfinance.ai
  */
-contract PriceAdapterRegistry is Initializable, IPriceAdapterRegistry, Ownable2StepUpgradeable, UUPSUpgradeable {
+contract PriceAdapterRegistry is Initializable, IPriceAdapterRegistry, UUPSUpgradeable {
     /// @notice Orion Config contract address
     address public configAddress;
 
@@ -46,14 +46,9 @@ contract PriceAdapterRegistry is Initializable, IPriceAdapterRegistry, Ownable2S
     }
 
     /// @notice Initializer function (replaces constructor)
-    /// @param initialOwner_ The address of the initial owner
     /// @param configAddress_ The address of the OrionConfig contract
-    function initialize(address initialOwner_, address configAddress_) public initializer {
-        if (initialOwner_ == address(0)) revert ErrorsLib.ZeroAddress();
+    function initialize(address configAddress_) public initializer {
         if (configAddress_ == address(0)) revert ErrorsLib.ZeroAddress();
-
-        __Ownable_init(initialOwner_);
-        __Ownable2Step_init();
 
         configAddress = configAddress_;
         underlyingAsset = address(IOrionConfig(configAddress).underlyingAsset());
@@ -87,12 +82,12 @@ contract PriceAdapterRegistry is Initializable, IPriceAdapterRegistry, Ownable2S
     }
 
     /// @notice Sets the upgrade timelock address.
-    /// @dev If no timelock is set yet, only the owner may call this. Once a timelock is active,
-    ///      only the timelock itself may replace it, preventing the owner from bypassing the delay.
+    /// @dev If no timelock is set yet, only the protocol admin may call this. Once a timelock is active,
+    ///      only the timelock itself may replace it, preventing the admin from bypassing the delay.
     /// @param newTimelock The new timelock address (e.g. OpenZeppelin TimelockController); address(0) not permitted
     function setUpgradeTimelock(address newTimelock) external {
         if (upgradeTimelock == address(0)) {
-            if (msg.sender != owner()) revert ErrorsLib.NotAuthorized();
+            if (msg.sender != Ownable(configAddress).owner()) revert ErrorsLib.NotAuthorized();
         } else {
             if (msg.sender != upgradeTimelock) revert ErrorsLib.NotAuthorized();
         }
@@ -102,14 +97,14 @@ contract PriceAdapterRegistry is Initializable, IPriceAdapterRegistry, Ownable2S
     }
 
     /// @notice Authorizes an upgrade to a new implementation
-    /// @dev Requires the caller to be the upgrade timelock (if set) or the owner (during initial
+    /// @dev Requires the caller to be the upgrade timelock (if set) or the protocol admin (during initial
     ///      bootstrapping before a timelock has been configured).
     // solhint-disable-next-line use-natspec
-    function _authorizeUpgrade(address) internal override {
+    function _authorizeUpgrade(address) internal view override {
         if (upgradeTimelock != address(0)) {
             if (msg.sender != upgradeTimelock) revert ErrorsLib.NotAuthorized();
         } else {
-            if (msg.sender != owner()) revert ErrorsLib.NotAuthorized();
+            if (msg.sender != Ownable(configAddress).owner()) revert ErrorsLib.NotAuthorized();
         }
     }
 

--- a/contracts/price/UniswapV3PoolPriceAdapter.sol
+++ b/contracts/price/UniswapV3PoolPriceAdapter.sol
@@ -2,8 +2,9 @@
 pragma solidity ^0.8.34;
 
 import "../interfaces/IPriceAdapter.sol";
+import { IOrionConfig } from "../interfaces/IOrionConfig.sol";
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import { IERC20Metadata } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
-import { Ownable2Step, Ownable } from "@openzeppelin/contracts/access/Ownable2Step.sol";
 import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 import { ErrorsLib } from "../libraries/ErrorsLib.sol";
 import { TickMath } from "@uniswap/v3-core/contracts/libraries/TickMath.sol";
@@ -25,7 +26,7 @@ import { IUniswapV3Pool } from "@uniswap/v3-core/contracts/interfaces/IUniswapV3
  * @custom:security-contact security@orionfinance.ai
  */
 
-contract UniswapV3PoolPriceAdapter is IPriceAdapter, Ownable2Step {
+contract UniswapV3PoolPriceAdapter is IPriceAdapter {
     using Math for uint256;
 
     /// @notice Minimum allowed TWAP window to avoid effectively-spot pricing.
@@ -64,6 +65,9 @@ contract UniswapV3PoolPriceAdapter is IPriceAdapter, Ownable2Step {
     /// @notice Extra price precision digits (matches ERC4626PriceAdapter for registry normalization).
     uint8 public constant PRICE_DECIMALS = 10;
 
+    /// @notice Orion Config contract
+    IOrionConfig public immutable CONFIG;
+
     /// @notice Protocol underlying (USDC).
     address public immutable USDC;
 
@@ -93,23 +97,31 @@ contract UniswapV3PoolPriceAdapter is IPriceAdapter, Ownable2Step {
     /// @param pool Uniswap V3 pool registered for the asset.
     event PoolSet(address indexed asset, address indexed pool);
 
+    /// @dev Restricts function to protocol admin
+    modifier onlyAdmin() {
+        if (msg.sender != Ownable(address(CONFIG)).owner()) revert ErrorsLib.NotAuthorized();
+        _;
+    }
+
     /// @notice Constructor
+    /// @param configAddress OrionConfig contract address
     /// @param usdc Protocol underlying (USDC)
-    /// @param initialOwner Ownable owner for setPool
     /// @param twapObserveSeconds_ TWAP window in seconds; must be >= MIN_TWAP_WINDOW
     /// @param minPoolLiquidity_ Minimum in-range liquidity; 0 skips
     /// @param minObservationCardinality_ Minimum observation cardinality at setPool; 0 skips
     /// @param maxObservationStalenessSeconds_ Max age of latest observation; 0 skips staleness guard
     constructor(
+        address configAddress,
         address usdc,
-        address initialOwner,
         uint32 twapObserveSeconds_,
         uint128 minPoolLiquidity_,
         uint16 minObservationCardinality_,
         uint32 maxObservationStalenessSeconds_
-    ) Ownable(initialOwner) {
+    ) {
+        if (configAddress == address(0)) revert ErrorsLib.ZeroAddress();
         if (usdc == address(0)) revert ErrorsLib.ZeroAddress();
         if (twapObserveSeconds_ < MIN_TWAP_WINDOW) revert ErrorsLib.InvalidArguments();
+        CONFIG = IOrionConfig(configAddress);
         USDC = usdc;
         USDC_DECIMALS = IERC20Metadata(usdc).decimals();
         TWAP_OBSERVE_SECONDS = twapObserveSeconds_;
@@ -122,7 +134,7 @@ contract UniswapV3PoolPriceAdapter is IPriceAdapter, Ownable2Step {
     /// @dev Pool tokens must be asset and USDC in either order. Probes observe TWAP horizon and staleness.
     /// @param asset ERC20 to price (not USDC)
     /// @param pool Uniswap V3 pool address
-    function setPool(address asset, address pool) external onlyOwner {
+    function setPool(address asset, address pool) external onlyAdmin {
         if (asset == address(0) || pool == address(0)) revert ErrorsLib.ZeroAddress();
         if (asset == USDC) revert ErrorsLib.InvalidAdapter(asset);
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orion-finance/protocol",
   "description": "Orion Finance Protocol",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "type": "module",
   "engines": {
     "node": ">=22.13.0"

--- a/test/ChainlinkPriceAdapterUnit.test.ts
+++ b/test/ChainlinkPriceAdapterUnit.test.ts
@@ -28,8 +28,15 @@ describe("ChainlinkPriceAdapter — unit tests", function () {
   const QUOTE_ANSWER = 1_00010000n; // $1.0001 in 8-dec fixed-point
 
   beforeEach(async function () {
+    const TokenF = await ethers.getContractFactory("MockUnderlyingAsset");
+    const usdc = await TokenF.deploy(6);
+    await usdc.waitForDeployment();
+    const ConfigF = await ethers.getContractFactory("MockOrionConfig");
+    const config = await ConfigF.deploy(await usdc.getAddress());
+    await config.waitForDeployment();
+
     const AdapterF = await ethers.getContractFactory("ChainlinkPriceAdapter");
-    adapter = (await AdapterF.deploy()) as unknown as ChainlinkPriceAdapter;
+    adapter = (await AdapterF.deploy(await config.getAddress())) as unknown as ChainlinkPriceAdapter;
     await adapter.waitForDeployment();
 
     const FeedF = await ethers.getContractFactory("MockChainlinkFeed");
@@ -183,7 +190,7 @@ describe("ChainlinkPriceAdapter — unit tests", function () {
         adapter
           .connect(nonOwner)
           .configureFeed(asset, await baseFeed.getAddress(), false, STALENESS, 1, MAX_PRICE, ethers.ZeroAddress),
-      ).to.be.revertedWithCustomError(adapter, "OwnableUnauthorizedAccount");
+      ).to.be.revertedWithCustomError(adapter, "NotAuthorized");
     });
   });
 
@@ -209,7 +216,7 @@ describe("ChainlinkPriceAdapter — unit tests", function () {
       const [, nonOwner] = await ethers.getSigners();
       await expect(
         adapter.connect(nonOwner).setFallbackAdapter(asset, await fallbackAdapter.getAddress()),
-      ).to.be.revertedWithCustomError(adapter, "OwnableUnauthorizedAccount");
+      ).to.be.revertedWithCustomError(adapter, "NotAuthorized");
     });
 
     it("rejects self as fallback adapter", async function () {

--- a/test/EncryptedVaultFactoryOrchestratorBranches.test.ts
+++ b/test/EncryptedVaultFactoryOrchestratorBranches.test.ts
@@ -72,7 +72,7 @@ describe("EncryptedVaultFactory / Config / LO edge branches", function () {
 
     const priceAdapterRegistry = await deployUUPSProxy<PriceAdapterRegistry>(
       "PriceAdapterRegistry",
-      [owner.address, await orionConfig.getAddress()],
+      [await orionConfig.getAddress()],
       owner,
     );
     await orionConfig.setPriceAdapterRegistry(await priceAdapterRegistry.getAddress());
@@ -84,13 +84,7 @@ describe("EncryptedVaultFactory / Config / LO edge branches", function () {
     const vKey = "0x007ccff4696ddd1d62fec2a106aa50309ba0fdee8fc2bcbc9c0b5ea68fe200f3";
     harness = await deployUUPSProxy<LiquidityOrchestratorHarness>(
       "LiquidityOrchestratorHarness",
-      [
-        owner.address,
-        await orionConfig.getAddress(),
-        automationRegistry.address,
-        await mockVerifier.getAddress(),
-        vKey,
-      ],
+      [await orionConfig.getAddress(), automationRegistry.address, await mockVerifier.getAddress(), vKey],
       owner,
     );
     await orionConfig.setLiquidityOrchestrator(await harness.getAddress());
@@ -107,7 +101,7 @@ describe("EncryptedVaultFactory / Config / LO edge branches", function () {
 
     transparentVaultFactory = await deployUUPSProxy<TransparentVaultFactory>(
       "TransparentVaultFactory",
-      [owner.address, await orionConfig.getAddress(), await transparentBeacon.getAddress()],
+      [await orionConfig.getAddress(), await transparentBeacon.getAddress()],
       owner,
     );
     await orionConfig.setVaultFactory(await transparentVaultFactory.getAddress());
@@ -123,7 +117,7 @@ describe("EncryptedVaultFactory / Config / LO edge branches", function () {
 
     encryptedVaultFactory = await deployUUPSProxy<EncryptedVaultFactory>(
       "EncryptedVaultFactory",
-      [owner.address, await orionConfig.getAddress(), await vaultBeacon.getAddress()],
+      [await orionConfig.getAddress(), await vaultBeacon.getAddress()],
       owner,
     );
     await orionConfig.setEncryptedVaultFactory(await encryptedVaultFactory.getAddress());
@@ -145,24 +139,13 @@ describe("EncryptedVaultFactory / Config / LO edge branches", function () {
   });
 
   describe("EncryptedVaultFactory", function () {
-    it("initialize rejects zero owner / config / beacon", async function () {
+    it("initialize rejects zero config / beacon", async function () {
       const Impl = await ethers.getContractFactory("EncryptedVaultFactory");
       const impl = await Impl.deploy();
       await impl.waitForDeployment();
       const Proxy = await ethers.getContractFactory("OrionERC1967Proxy");
 
-      const badOwner = Impl.interface.encodeFunctionData("initialize", [
-        ethers.ZeroAddress,
-        await orionConfig.getAddress(),
-        await vaultBeacon.getAddress(),
-      ]);
-      await expect(Proxy.deploy(await impl.getAddress(), badOwner)).to.be.revertedWithCustomError(
-        encryptedVaultFactory,
-        "ZeroAddress",
-      );
-
       const badConfig = Impl.interface.encodeFunctionData("initialize", [
-        owner.address,
         ethers.ZeroAddress,
         await vaultBeacon.getAddress(),
       ]);
@@ -172,7 +155,6 @@ describe("EncryptedVaultFactory / Config / LO edge branches", function () {
       );
 
       const badBeacon = Impl.interface.encodeFunctionData("initialize", [
-        owner.address,
         await orionConfig.getAddress(),
         ethers.ZeroAddress,
       ]);

--- a/test/EpochStateCommitmentBinding.test.ts
+++ b/test/EpochStateCommitmentBinding.test.ts
@@ -141,7 +141,7 @@ describe("EpochStateCommitmentBinding", function () {
 
     const priceAdapterRegistry = await deployUUPSProxy<PriceAdapterRegistry>(
       "PriceAdapterRegistry",
-      [owner.address, await orionConfig.getAddress()],
+      [await orionConfig.getAddress()],
       owner,
     );
     await orionConfig.setPriceAdapterRegistry(await priceAdapterRegistry.getAddress());
@@ -153,13 +153,7 @@ describe("EpochStateCommitmentBinding", function () {
     const vKey = "0x007ccff4696ddd1d62fec2a106aa50309ba0fdee8fc2bcbc9c0b5ea68fe200f3";
     harness = await deployUUPSProxy<LiquidityOrchestratorCommitmentHarness>(
       "LiquidityOrchestratorCommitmentHarness",
-      [
-        owner.address,
-        await orionConfig.getAddress(),
-        automationRegistry.address,
-        await mockVerifier.getAddress(),
-        vKey,
-      ],
+      [await orionConfig.getAddress(), automationRegistry.address, await mockVerifier.getAddress(), vKey],
       owner,
     );
     await orionConfig.setLiquidityOrchestrator(await harness.getAddress());
@@ -176,7 +170,7 @@ describe("EpochStateCommitmentBinding", function () {
 
     transparentVaultFactory = await deployUUPSProxy<TransparentVaultFactory>(
       "TransparentVaultFactory",
-      [owner.address, await orionConfig.getAddress(), await vaultBeacon.getAddress()],
+      [await orionConfig.getAddress(), await vaultBeacon.getAddress()],
       owner,
     );
     await orionConfig.setVaultFactory(await transparentVaultFactory.getAddress());
@@ -294,7 +288,7 @@ describe("EpochStateCommitmentBinding", function () {
       );
       const priceAdapterRegistry = await deployUUPSProxy<PriceAdapterRegistry>(
         "PriceAdapterRegistry",
-        [owner.address, await orionConfig.getAddress()],
+        [await orionConfig.getAddress()],
         owner,
       );
       await orionConfig.setPriceAdapterRegistry(await priceAdapterRegistry.getAddress());
@@ -305,13 +299,7 @@ describe("EpochStateCommitmentBinding", function () {
       const vKey = "0x007ccff4696ddd1d62fec2a106aa50309ba0fdee8fc2bcbc9c0b5ea68fe200f3";
       harness = await deployUUPSProxy<LiquidityOrchestratorCommitmentHarness>(
         "LiquidityOrchestratorCommitmentHarness",
-        [
-          owner.address,
-          await orionConfig.getAddress(),
-          automationRegistry.address,
-          await mockVerifier.getAddress(),
-          vKey,
-        ],
+        [await orionConfig.getAddress(), automationRegistry.address, await mockVerifier.getAddress(), vKey],
         owner,
       );
       await orionConfig.setLiquidityOrchestrator(await harness.getAddress());
@@ -322,7 +310,7 @@ describe("EpochStateCommitmentBinding", function () {
       ).deploy(await vaultImpl.getAddress(), owner.address)) as unknown as UpgradeableBeacon;
       transparentVaultFactory = await deployUUPSProxy<TransparentVaultFactory>(
         "TransparentVaultFactory",
-        [owner.address, await orionConfig.getAddress(), await vaultBeacon.getAddress()],
+        [await orionConfig.getAddress(), await vaultBeacon.getAddress()],
         owner,
       );
       await orionConfig.setVaultFactory(await transparentVaultFactory.getAddress());

--- a/test/LiquidityOrchestratorBufferAccrual.test.ts
+++ b/test/LiquidityOrchestratorBufferAccrual.test.ts
@@ -100,7 +100,7 @@ describe("LiquidityOrchestrator – deferred buffer and fee accrual", function (
 
     const registry = await deployUUPSProxy<PriceAdapterRegistry>(
       "PriceAdapterRegistry",
-      [owner.address, await orionConfig.getAddress()],
+      [await orionConfig.getAddress()],
       owner,
     );
     await orionConfig.setPriceAdapterRegistry(await registry.getAddress());
@@ -112,13 +112,7 @@ describe("LiquidityOrchestrator – deferred buffer and fee accrual", function (
     const vKey = "0x007ccff4696ddd1d62fec2a106aa50309ba0fdee8fc2bcbc9c0b5ea68fe200f3";
     harness = await deployUUPSProxy<LiquidityOrchestratorBufferHarness>(
       "LiquidityOrchestratorBufferHarness",
-      [
-        owner.address,
-        await orionConfig.getAddress(),
-        automationRegistry.address,
-        await mockVerifier.getAddress(),
-        vKey,
-      ],
+      [await orionConfig.getAddress(), automationRegistry.address, await mockVerifier.getAddress(), vKey],
       owner,
     );
     await orionConfig.setLiquidityOrchestrator(await harness.getAddress());

--- a/test/LiquidityOrchestratorCallbacks.test.ts
+++ b/test/LiquidityOrchestratorCallbacks.test.ts
@@ -37,7 +37,7 @@ describe("LiquidityOrchestrator callbacks and protocol fee claims", function () 
 
     const priceAdapterRegistry = await deployUUPSProxy<PriceAdapterRegistry>(
       "PriceAdapterRegistry",
-      [owner.address, await orionConfig.getAddress()],
+      [await orionConfig.getAddress()],
       owner,
     );
     await orionConfig.setPriceAdapterRegistry(await priceAdapterRegistry.getAddress());
@@ -53,7 +53,7 @@ describe("LiquidityOrchestrator callbacks and protocol fee claims", function () 
     const vKey = "0x007ccff4696ddd1d62fec2a106aa50309ba0fdee8fc2bcbc9c0b5ea68fe200f3";
     const harness = await deployUUPSProxy<LiquidityOrchestratorBufferHarness>(
       "LiquidityOrchestratorBufferHarness",
-      [owner.address, await orionConfig.getAddress(), owner.address, await sp1VerifierGateway.getAddress(), vKey],
+      [await orionConfig.getAddress(), owner.address, await sp1VerifierGateway.getAddress(), vKey],
       owner,
     );
     await orionConfig.setLiquidityOrchestrator(await harness.getAddress());
@@ -67,7 +67,7 @@ describe("LiquidityOrchestrator callbacks and protocol fee claims", function () 
 
     const transparentVaultFactory = await deployUUPSProxy<TransparentVaultFactory>(
       "TransparentVaultFactory",
-      [owner.address, await orionConfig.getAddress(), await vaultBeacon.getAddress()],
+      [await orionConfig.getAddress(), await vaultBeacon.getAddress()],
       owner,
     );
     await orionConfig.setVaultFactory(await transparentVaultFactory.getAddress());
@@ -119,7 +119,7 @@ describe("LiquidityOrchestrator callbacks and protocol fee claims", function () 
 
       await expect(harness.connect(stranger).claimProtocolFees(1)).to.be.revertedWithCustomError(
         harness,
-        "OwnableUnauthorizedAccount",
+        "NotAuthorized",
       );
 
       await expect(harness.connect(owner).claimProtocolFees(0)).to.be.revertedWithCustomError(

--- a/test/LiquidityOrchestratorEncrypted.test.ts
+++ b/test/LiquidityOrchestratorEncrypted.test.ts
@@ -138,7 +138,7 @@ describe("LiquidityOrchestrator – encrypted vaults", function () {
 
     const priceAdapterRegistry = await deployUUPSProxy<PriceAdapterRegistry>(
       "PriceAdapterRegistry",
-      [owner.address, await orionConfig.getAddress()],
+      [await orionConfig.getAddress()],
       owner,
     );
     await orionConfig.setPriceAdapterRegistry(await priceAdapterRegistry.getAddress());
@@ -150,13 +150,7 @@ describe("LiquidityOrchestrator – encrypted vaults", function () {
     const vKey = "0x007ccff4696ddd1d62fec2a106aa50309ba0fdee8fc2bcbc9c0b5ea68fe200f3";
     harness = await deployUUPSProxy<LiquidityOrchestratorVaultHarness>(
       "LiquidityOrchestratorVaultHarness",
-      [
-        owner.address,
-        await orionConfig.getAddress(),
-        automationRegistry.address,
-        await mockVerifier.getAddress(),
-        vKey,
-      ],
+      [await orionConfig.getAddress(), automationRegistry.address, await mockVerifier.getAddress(), vKey],
       owner,
     );
     await orionConfig.setLiquidityOrchestrator(await harness.getAddress());
@@ -173,7 +167,7 @@ describe("LiquidityOrchestrator – encrypted vaults", function () {
 
     transparentVaultFactory = await deployUUPSProxy<TransparentVaultFactory>(
       "TransparentVaultFactory",
-      [owner.address, await orionConfig.getAddress(), await transparentBeacon.getAddress()],
+      [await orionConfig.getAddress(), await transparentBeacon.getAddress()],
       owner,
     );
     await orionConfig.setVaultFactory(await transparentVaultFactory.getAddress());
@@ -189,7 +183,7 @@ describe("LiquidityOrchestrator – encrypted vaults", function () {
 
     encryptedVaultFactory = await deployUUPSProxy<EncryptedVaultFactory>(
       "EncryptedVaultFactory",
-      [owner.address, await orionConfig.getAddress(), await encryptedBeacon.getAddress()],
+      [await orionConfig.getAddress(), await encryptedBeacon.getAddress()],
       owner,
     );
     await orionConfig.setEncryptedVaultFactory(await encryptedVaultFactory.getAddress());

--- a/test/LiquidityOrchestratorEpochEnd.test.ts
+++ b/test/LiquidityOrchestratorEpochEnd.test.ts
@@ -96,7 +96,7 @@ describe("LiquidityOrchestrator epoch-end gating", function () {
 
     const priceAdapterRegistry = await deployUUPSProxy<PriceAdapterRegistry>(
       "PriceAdapterRegistry",
-      [owner.address, await orionConfig.getAddress()],
+      [await orionConfig.getAddress()],
       owner,
     );
     await orionConfig.setPriceAdapterRegistry(await priceAdapterRegistry.getAddress());
@@ -112,7 +112,7 @@ describe("LiquidityOrchestrator epoch-end gating", function () {
     const vKey = "0x007ccff4696ddd1d62fec2a106aa50309ba0fdee8fc2bcbc9c0b5ea68fe200f3";
     harness = await deployUUPSProxy<LiquidityOrchestratorEpochEndHarness>(
       "LiquidityOrchestratorEpochEndHarness",
-      [owner.address, await orionConfig.getAddress(), owner.address, await sp1VerifierGateway.getAddress(), vKey],
+      [await orionConfig.getAddress(), owner.address, await sp1VerifierGateway.getAddress(), vKey],
       owner,
     );
     await orionConfig.setLiquidityOrchestrator(await harness.getAddress());
@@ -129,7 +129,7 @@ describe("LiquidityOrchestrator epoch-end gating", function () {
 
     transparentVaultFactory = await deployUUPSProxy<TransparentVaultFactory>(
       "TransparentVaultFactory",
-      [owner.address, await orionConfig.getAddress(), await vaultBeacon.getAddress()],
+      [await orionConfig.getAddress(), await vaultBeacon.getAddress()],
       owner,
     );
     await orionConfig.setVaultFactory(await transparentVaultFactory.getAddress());

--- a/test/LiquidityOrchestratorPhases.test.ts
+++ b/test/LiquidityOrchestratorPhases.test.ts
@@ -103,7 +103,7 @@ describe("LiquidityOrchestrator – config ACL and performUpkeep phases", functi
 
     const priceAdapterRegistry = await deployUUPSProxy<PriceAdapterRegistry>(
       "PriceAdapterRegistry",
-      [owner.address, await orionConfig.getAddress()],
+      [await orionConfig.getAddress()],
       owner,
     );
     await orionConfig.setPriceAdapterRegistry(await priceAdapterRegistry.getAddress());
@@ -115,13 +115,7 @@ describe("LiquidityOrchestrator – config ACL and performUpkeep phases", functi
     const vKey = "0x007ccff4696ddd1d62fec2a106aa50309ba0fdee8fc2bcbc9c0b5ea68fe200f3";
     harness = await deployUUPSProxy<LiquidityOrchestratorHarness>(
       "LiquidityOrchestratorHarness",
-      [
-        owner.address,
-        await orionConfig.getAddress(),
-        automationRegistry.address,
-        await mockVerifier.getAddress(),
-        vKey,
-      ],
+      [await orionConfig.getAddress(), automationRegistry.address, await mockVerifier.getAddress(), vKey],
       owner,
     );
     await orionConfig.setLiquidityOrchestrator(await harness.getAddress());
@@ -139,7 +133,7 @@ describe("LiquidityOrchestrator – config ACL and performUpkeep phases", functi
 
     transparentVaultFactory = await deployUUPSProxy<TransparentVaultFactory>(
       "TransparentVaultFactory",
-      [owner.address, await orionConfig.getAddress(), await vaultBeacon.getAddress()],
+      [await orionConfig.getAddress(), await vaultBeacon.getAddress()],
       owner,
     );
     await orionConfig.setVaultFactory(await transparentVaultFactory.getAddress());
@@ -169,11 +163,11 @@ describe("LiquidityOrchestrator – config ACL and performUpkeep phases", functi
       );
       await expect(harness.connect(stranger).updateCommitmentMinibatchSize(2)).to.be.revertedWithCustomError(
         harness,
-        "OwnableUnauthorizedAccount",
+        "NotAuthorized",
       );
       await expect(harness.connect(guardian).updateCommitmentMinibatchSize(2)).to.be.revertedWithCustomError(
         harness,
-        "OwnableUnauthorizedAccount",
+        "NotAuthorized",
       );
     });
 
@@ -212,11 +206,11 @@ describe("LiquidityOrchestrator – config ACL and performUpkeep phases", functi
       );
       await expect(harness.connect(guardian).updateVerifier(await next.getAddress())).to.be.revertedWithCustomError(
         harness,
-        "OwnableUnauthorizedAccount",
+        "NotAuthorized",
       );
       await expect(harness.connect(stranger).updateVerifier(await next.getAddress())).to.be.revertedWithCustomError(
         harness,
-        "OwnableUnauthorizedAccount",
+        "NotAuthorized",
       );
     });
 
@@ -231,7 +225,7 @@ describe("LiquidityOrchestrator – config ACL and performUpkeep phases", functi
       );
       await expect(harness.connect(guardian).updateVKey(newKey)).to.be.revertedWithCustomError(
         harness,
-        "OwnableUnauthorizedAccount",
+        "NotAuthorized",
       );
     });
   });

--- a/test/LiquidityOrchestratorSlippage.test.ts
+++ b/test/LiquidityOrchestratorSlippage.test.ts
@@ -57,7 +57,7 @@ describe("LiquidityOrchestrator - Centralized Slippage Management", function () 
     // --- Deploy PriceAdapterRegistry proxy ---
     const priceAdapterRegistry = await deployUUPSProxy<PriceAdapterRegistry>(
       "PriceAdapterRegistry",
-      [owner.address, await orionConfig.getAddress()],
+      [await orionConfig.getAddress()],
       owner,
     );
     await orionConfig.setPriceAdapterRegistry(await priceAdapterRegistry.getAddress());
@@ -77,7 +77,7 @@ describe("LiquidityOrchestrator - Centralized Slippage Management", function () 
     // --- Deploy LiquidityOrchestratorSlippageHarness proxy ---
     harness = await deployUUPSProxy<LiquidityOrchestratorSlippageHarness>(
       "LiquidityOrchestratorSlippageHarness",
-      [owner.address, await orionConfig.getAddress(), owner.address, await sp1VerifierGateway.getAddress(), vKey],
+      [await orionConfig.getAddress(), owner.address, await sp1VerifierGateway.getAddress(), vKey],
       owner,
     );
 
@@ -132,7 +132,7 @@ describe("LiquidityOrchestrator - Centralized Slippage Management", function () 
 
     const transparentVaultFactory = await deployUUPSProxy(
       "TransparentVaultFactory",
-      [owner.address, await orionConfig.getAddress(), await vaultBeacon.getAddress()],
+      [await orionConfig.getAddress(), await vaultBeacon.getAddress()],
       owner,
     );
     await orionConfig.setVaultFactory(await transparentVaultFactory.getAddress());

--- a/test/OrionEncryptedVault.test.ts
+++ b/test/OrionEncryptedVault.test.ts
@@ -107,7 +107,7 @@ describe("OrionEncryptedVault", function () {
 
     encryptedVaultFactory = await deployUUPSProxy<EncryptedVaultFactory>(
       "EncryptedVaultFactory",
-      [owner.address, await orionConfig.getAddress(), await vaultBeacon.getAddress()],
+      [await orionConfig.getAddress(), await vaultBeacon.getAddress()],
       owner,
     );
     await orionConfig.setEncryptedVaultFactory(await encryptedVaultFactory.getAddress());

--- a/test/OrionEncryptedVaultHpke.test.ts
+++ b/test/OrionEncryptedVaultHpke.test.ts
@@ -121,7 +121,7 @@ describe("OrionEncryptedVault – HPKE intent submit", function () {
 
     encryptedVaultFactory = await deployUUPSProxy<EncryptedVaultFactory>(
       "EncryptedVaultFactory",
-      [owner.address, await orionConfig.getAddress(), await vaultBeacon.getAddress()],
+      [await orionConfig.getAddress(), await vaultBeacon.getAddress()],
       owner,
     );
     await orionConfig.setEncryptedVaultFactory(await encryptedVaultFactory.getAddress());

--- a/test/OrionVaultConfigOrchestratorBranches.test.ts
+++ b/test/OrionVaultConfigOrchestratorBranches.test.ts
@@ -83,7 +83,7 @@ describe("OrionVault / OrionConfig / LO edge branches", function () {
 
     priceAdapterRegistry = await deployUUPSProxy<PriceAdapterRegistry>(
       "PriceAdapterRegistry",
-      [owner.address, await orionConfig.getAddress()],
+      [await orionConfig.getAddress()],
       owner,
     );
     await orionConfig.setPriceAdapterRegistry(await priceAdapterRegistry.getAddress());
@@ -99,7 +99,7 @@ describe("OrionVault / OrionConfig / LO edge branches", function () {
     const vKey = "0x007ccff4696ddd1d62fec2a106aa50309ba0fdee8fc2bcbc9c0b5ea68fe200f3";
     harness = await deployUUPSProxy<LiquidityOrchestratorVaultHarness>(
       "LiquidityOrchestratorVaultHarness",
-      [owner.address, await orionConfig.getAddress(), owner.address, await gateway.getAddress(), vKey],
+      [await orionConfig.getAddress(), owner.address, await gateway.getAddress(), vKey],
       owner,
     );
     await orionConfig.setLiquidityOrchestrator(await harness.getAddress());
@@ -116,7 +116,7 @@ describe("OrionVault / OrionConfig / LO edge branches", function () {
 
     transparentVaultFactory = await deployUUPSProxy<TransparentVaultFactory>(
       "TransparentVaultFactory",
-      [owner.address, await orionConfig.getAddress(), await vaultBeacon.getAddress()],
+      [await orionConfig.getAddress(), await vaultBeacon.getAddress()],
       owner,
     );
     await orionConfig.setVaultFactory(await transparentVaultFactory.getAddress());
@@ -580,11 +580,10 @@ describe("OrionVault / OrionConfig / LO edge branches", function () {
       const gateway = await harness.verifier();
 
       const cases = [
-        [ethers.ZeroAddress, await orionConfig.getAddress(), owner.address, gateway, vKey],
-        [owner.address, ethers.ZeroAddress, owner.address, gateway, vKey],
-        [owner.address, await orionConfig.getAddress(), ethers.ZeroAddress, gateway, vKey],
-        [owner.address, await orionConfig.getAddress(), owner.address, ethers.ZeroAddress, vKey],
-        [owner.address, await orionConfig.getAddress(), owner.address, gateway, ethers.ZeroHash],
+        [ethers.ZeroAddress, owner.address, gateway, vKey],
+        [await orionConfig.getAddress(), ethers.ZeroAddress, gateway, vKey],
+        [await orionConfig.getAddress(), owner.address, ethers.ZeroAddress, vKey],
+        [await orionConfig.getAddress(), owner.address, gateway, ethers.ZeroHash],
       ];
       for (const args of cases) {
         const data = Impl.interface.encodeFunctionData("initialize", args);
@@ -639,11 +638,11 @@ describe("OrionVault / OrionConfig / LO edge branches", function () {
       await harness.connect(owner).updateExecutionMinibatchSize(2);
       await expect(harness.connect(guardian).updateMinibatchSize(2)).to.be.revertedWithCustomError(
         harness,
-        "OwnableUnauthorizedAccount",
+        "NotAuthorized",
       );
       await expect(harness.connect(guardian).updateExecutionMinibatchSize(2)).to.be.revertedWithCustomError(
         harness,
-        "OwnableUnauthorizedAccount",
+        "NotAuthorized",
       );
       await harness.connect(owner).updateMinibatchSize(2);
       await harness.connect(owner).setTargetBufferRatio(50);
@@ -843,7 +842,10 @@ describe("Adapters / strategies / registry edge branches", function () {
   });
 
   it("ChainlinkPriceAdapter rejects scaleFactor==0 when base decimals dominate", async function () {
-    const adapter = await (await ethers.getContractFactory("ChainlinkPriceAdapter")).deploy();
+    const usdc = await (await ethers.getContractFactory("MockUnderlyingAsset")).deploy(6);
+    const MockConfig = await ethers.getContractFactory("MockOrionConfig");
+    const config = await MockConfig.deploy(await usdc.getAddress());
+    const adapter = await (await ethers.getContractFactory("ChainlinkPriceAdapter")).deploy(await config.getAddress());
     // 10^(0+18)/10^77 truncates to 0 without overflowing 10**exp (max safe ~77)
     const base = await (await ethers.getContractFactory("MockChainlinkFeed")).deploy(77, 1n);
     const quote = await (await ethers.getContractFactory("MockChainlinkFeed")).deploy(0, 1n);
@@ -890,7 +892,6 @@ describe("Adapters / strategies / registry edge branches", function () {
     await impl.waitForDeployment();
     const Proxy = await ethers.getContractFactory("OrionERC1967Proxy");
     const badConfig = Impl.interface.encodeFunctionData("initialize", [
-      owner.address,
       ethers.ZeroAddress,
       await deployed.vaultBeacon.getAddress(),
     ]);
@@ -899,7 +900,6 @@ describe("Adapters / strategies / registry edge branches", function () {
       "ZeroAddress",
     );
     const badBeacon = Impl.interface.encodeFunctionData("initialize", [
-      owner.address,
       await deployed.orionConfig.getAddress(),
       ethers.ZeroAddress,
     ]);
@@ -1045,7 +1045,7 @@ describe("OrionConfig bootstrap and guardian ACL (merged)", function () {
     const { orionConfig, owner } = fixture;
     const priceAdapterRegistry = await deployUUPSProxy<PriceAdapterRegistry>(
       "PriceAdapterRegistry",
-      [owner.address, await orionConfig.getAddress()],
+      [await orionConfig.getAddress()],
       owner,
     );
     await orionConfig.connect(owner).setPriceAdapterRegistry(await priceAdapterRegistry.getAddress());
@@ -1059,7 +1059,7 @@ describe("OrionConfig bootstrap and guardian ACL (merged)", function () {
     const vKey = "0x007ccff4696ddd1d62fec2a106aa50309ba0fdee8fc2bcbc9c0b5ea68fe200f3";
     const lo = await deployUUPSProxy(
       "LiquidityOrchestrator",
-      [owner.address, await orionConfig.getAddress(), owner.address, await gateway.getAddress(), vKey],
+      [await orionConfig.getAddress(), owner.address, await gateway.getAddress(), vKey],
       owner,
     );
     await orionConfig.connect(owner).setLiquidityOrchestrator(await lo.getAddress());
@@ -1109,7 +1109,7 @@ describe("OrionConfig bootstrap and guardian ACL (merged)", function () {
     await vaultBeacon.waitForDeployment();
     const factory = await deployUUPSProxy(
       "TransparentVaultFactory",
-      [owner.address, await orionConfig.getAddress(), await vaultBeacon.getAddress()],
+      [await orionConfig.getAddress(), await vaultBeacon.getAddress()],
       owner,
     );
     await orionConfig.connect(owner).setVaultFactory(await factory.getAddress());

--- a/test/PriceAdapterRegistry.test.ts
+++ b/test/PriceAdapterRegistry.test.ts
@@ -87,22 +87,13 @@ describe("PriceAdapterRegistry", function () {
   });
 
   describe("initialize", function () {
-    it("should reject zero owner or config on initialize via proxy", async function () {
+    it("should reject zero config on initialize via proxy", async function () {
       const Impl = await ethers.getContractFactory("PriceAdapterRegistry");
       const impl = await Impl.deploy();
       await impl.waitForDeployment();
 
       const Proxy = await ethers.getContractFactory("OrionERC1967Proxy");
-      const initBadOwner = Impl.interface.encodeFunctionData("initialize", [
-        ethers.ZeroAddress,
-        await orionConfig.getAddress(),
-      ]);
-      await expect(Proxy.deploy(await impl.getAddress(), initBadOwner)).to.be.revertedWithCustomError(
-        priceAdapterRegistry,
-        "ZeroAddress",
-      );
-
-      const initBadConfig = Impl.interface.encodeFunctionData("initialize", [owner.address, ethers.ZeroAddress]);
+      const initBadConfig = Impl.interface.encodeFunctionData("initialize", [ethers.ZeroAddress]);
       await expect(Proxy.deploy(await impl.getAddress(), initBadConfig)).to.be.revertedWithCustomError(
         priceAdapterRegistry,
         "ZeroAddress",

--- a/test/ProtocolPause.test.ts
+++ b/test/ProtocolPause.test.ts
@@ -250,7 +250,7 @@ describe("Protocol Pause Functionality", function () {
     it("should prevent guardian from unpausing (only owner)", async function () {
       await expect(liquidityOrchestrator.connect(guardian).unpause()).to.be.revertedWithCustomError(
         liquidityOrchestrator,
-        "OwnableUnauthorizedAccount",
+        "NotAuthorized",
       );
 
       // Verify everything is still paused
@@ -260,7 +260,7 @@ describe("Protocol Pause Functionality", function () {
     it("should prevent non-owner from unpausing", async function () {
       await expect(liquidityOrchestrator.connect(user1).unpause()).to.be.revertedWithCustomError(
         liquidityOrchestrator,
-        "OwnableUnauthorizedAccount",
+        "NotAuthorized",
       );
 
       // Verify everything is still paused

--- a/test/TransparentVault.test.ts
+++ b/test/TransparentVault.test.ts
@@ -203,12 +203,11 @@ describe("TransparentVault - Strategist Pipeline", function () {
       const impl = await Impl.deploy();
       await impl.waitForDeployment();
       const Proxy = await ethers.getContractFactory("OrionERC1967Proxy");
-      const badOwner = Impl.interface.encodeFunctionData("initialize", [
+      const badInit = Impl.interface.encodeFunctionData("initialize", [
         ethers.ZeroAddress,
-        await orionConfig.getAddress(),
         await transparentVaultFactory.vaultBeacon(),
       ]);
-      await expect(Proxy.deploy(await impl.getAddress(), badOwner)).to.be.revertedWithCustomError(
+      await expect(Proxy.deploy(await impl.getAddress(), badInit)).to.be.revertedWithCustomError(
         transparentVaultFactory,
         "ZeroAddress",
       );

--- a/test/UniswapV3PoolPriceAdapter.test.ts
+++ b/test/UniswapV3PoolPriceAdapter.test.ts
@@ -4,13 +4,13 @@
 
 import { expect } from "chai";
 import { ethers } from "./helpers/hh";
-import type { MockUnderlyingAsset, UniswapV3PoolPriceAdapter } from "../typechain-types";
+import type { MockUnderlyingAsset, MockOrionConfig, UniswapV3PoolPriceAdapter } from "../typechain-types";
 
 const TWAP = 300;
 const SQRT_OK = 1n << 96n; // ~1.0 price
 
 describe("UniswapV3PoolPriceAdapter — unit tests", function () {
-  let owner: Awaited<ReturnType<typeof ethers.getSigners>>[0];
+  let config: MockOrionConfig;
   let usdc: MockUnderlyingAsset;
   let asset: MockUnderlyingAsset;
   let adapter: UniswapV3PoolPriceAdapter;
@@ -30,17 +30,20 @@ describe("UniswapV3PoolPriceAdapter — unit tests", function () {
   }
 
   beforeEach(async function () {
-    [owner] = await ethers.getSigners();
     const TokenF = await ethers.getContractFactory("MockUnderlyingAsset");
     usdc = (await TokenF.deploy(6)) as unknown as MockUnderlyingAsset;
     asset = (await TokenF.deploy(18)) as unknown as MockUnderlyingAsset;
     await usdc.waitForDeployment();
     await asset.waitForDeployment();
 
+    const ConfigF = await ethers.getContractFactory("MockOrionConfig");
+    config = (await ConfigF.deploy(await usdc.getAddress())) as unknown as MockOrionConfig;
+    await config.waitForDeployment();
+
     const AdapterF = await ethers.getContractFactory("UniswapV3PoolPriceAdapter");
     adapter = (await AdapterF.deploy(
+      await config.getAddress(),
       await usdc.getAddress(),
-      owner.address,
       TWAP,
       0, // min liquidity skip
       0, // min cardinality skip
@@ -52,18 +55,16 @@ describe("UniswapV3PoolPriceAdapter — unit tests", function () {
   describe("constructor", function () {
     it("should reject zero USDC", async function () {
       const AdapterF = await ethers.getContractFactory("UniswapV3PoolPriceAdapter");
-      await expect(AdapterF.deploy(ethers.ZeroAddress, owner.address, TWAP, 0, 0, 0)).to.be.revertedWithCustomError(
-        adapter,
-        "ZeroAddress",
-      );
+      await expect(
+        AdapterF.deploy(await config.getAddress(), ethers.ZeroAddress, TWAP, 0, 0, 0),
+      ).to.be.revertedWithCustomError(adapter, "ZeroAddress");
     });
 
     it("should reject TWAP window below minimum", async function () {
       const AdapterF = await ethers.getContractFactory("UniswapV3PoolPriceAdapter");
-      await expect(AdapterF.deploy(await usdc.getAddress(), owner.address, 1, 0, 0, 0)).to.be.revertedWithCustomError(
-        adapter,
-        "InvalidArguments",
-      );
+      await expect(
+        AdapterF.deploy(await config.getAddress(), await usdc.getAddress(), 1, 0, 0, 0),
+      ).to.be.revertedWithCustomError(adapter, "InvalidArguments");
     });
   });
 
@@ -176,8 +177,8 @@ describe("UniswapV3PoolPriceAdapter — unit tests", function () {
     it("should reject stale observations when staleness is configured", async function () {
       const AdapterF = await ethers.getContractFactory("UniswapV3PoolPriceAdapter");
       const staleAdapter = (await AdapterF.deploy(
+        await config.getAddress(),
         await usdc.getAddress(),
-        owner.address,
         TWAP,
         0,
         0,

--- a/test/Upgrade.test.ts
+++ b/test/Upgrade.test.ts
@@ -667,7 +667,7 @@ describe("Upgrade Tests", function () {
       // Call upgradeToAndCall directly, executing _authorizeUpgrade
       await priceAdapterRegistry.connect(owner).upgradeToAndCall(await newImpl.getAddress(), "0x");
 
-      expect(await priceAdapterRegistry.owner()).to.equal(owner.address);
+      expect(await orionConfig.owner()).to.equal(owner.address);
     });
 
     it("Should cover PriceAdapterRegistry._authorizeUpgrade revert on non-owner", async function () {
@@ -688,7 +688,7 @@ describe("Upgrade Tests", function () {
       // Call upgradeToAndCall directly, executing _authorizeUpgrade
       await liquidityOrchestrator.connect(owner).upgradeToAndCall(await newImpl.getAddress(), "0x");
 
-      expect(await liquidityOrchestrator.owner()).to.equal(owner.address);
+      expect(await orionConfig.owner()).to.equal(owner.address);
     });
 
     it("Should cover LiquidityOrchestrator._authorizeUpgrade revert on non-owner", async function () {
@@ -709,7 +709,7 @@ describe("Upgrade Tests", function () {
       // Call upgradeToAndCall directly, executing _authorizeUpgrade
       await transparentVaultFactory.connect(owner).upgradeToAndCall(await newImpl.getAddress(), "0x");
 
-      expect(await transparentVaultFactory.owner()).to.equal(owner.address);
+      expect(await orionConfig.owner()).to.equal(owner.address);
     });
 
     it("Should cover TransparentVaultFactory._authorizeUpgrade revert on non-owner", async function () {

--- a/test/VaultDecommissioning.test.ts
+++ b/test/VaultDecommissioning.test.ts
@@ -91,7 +91,7 @@ describe("Vault decommissioning completion", function () {
 
     const priceAdapterRegistry = await deployUUPSProxy<PriceAdapterRegistry>(
       "PriceAdapterRegistry",
-      [owner.address, await orionConfig.getAddress()],
+      [await orionConfig.getAddress()],
       owner,
     );
     await orionConfig.setPriceAdapterRegistry(await priceAdapterRegistry.getAddress());
@@ -107,7 +107,7 @@ describe("Vault decommissioning completion", function () {
     const vKey = "0x007ccff4696ddd1d62fec2a106aa50309ba0fdee8fc2bcbc9c0b5ea68fe200f3";
     harness = await deployUUPSProxy<LiquidityOrchestratorVaultHarness>(
       "LiquidityOrchestratorVaultHarness",
-      [owner.address, await orionConfig.getAddress(), owner.address, await sp1VerifierGateway.getAddress(), vKey],
+      [await orionConfig.getAddress(), owner.address, await sp1VerifierGateway.getAddress(), vKey],
       owner,
     );
     await orionConfig.setLiquidityOrchestrator(await harness.getAddress());
@@ -124,7 +124,7 @@ describe("Vault decommissioning completion", function () {
 
     transparentVaultFactory = await deployUUPSProxy<TransparentVaultFactory>(
       "TransparentVaultFactory",
-      [owner.address, await orionConfig.getAddress(), await vaultBeacon.getAddress()],
+      [await orionConfig.getAddress(), await vaultBeacon.getAddress()],
       owner,
     );
     await orionConfig.setVaultFactory(await transparentVaultFactory.getAddress());

--- a/test/helpers/deployUpgradeable.ts
+++ b/test/helpers/deployUpgradeable.ts
@@ -82,7 +82,7 @@ export async function deployUpgradeableProtocol(
   // 2. Deploy PriceAdapterRegistry proxy and set in config
   const priceAdapterRegistry = await deployUUPSProxy<PriceAdapterRegistry>(
     "PriceAdapterRegistry",
-    [owner.address, await orionConfig.getAddress()],
+    [await orionConfig.getAddress()],
     owner,
   );
 
@@ -104,7 +104,7 @@ export async function deployUpgradeableProtocol(
 
   const liquidityOrchestrator = await deployUUPSProxy<LiquidityOrchestrator>(
     "LiquidityOrchestrator",
-    [owner.address, await orionConfig.getAddress(), automationReg.address, await sp1VerifierGateway.getAddress(), vKey],
+    [await orionConfig.getAddress(), automationReg.address, await sp1VerifierGateway.getAddress(), vKey],
     owner,
   );
 
@@ -126,7 +126,7 @@ export async function deployUpgradeableProtocol(
   // 6. Deploy TransparentVaultFactory proxy
   const transparentVaultFactory = await deployUUPSProxy<TransparentVaultFactory>(
     "TransparentVaultFactory",
-    [owner.address, await orionConfig.getAddress(), await vaultBeacon.getAddress()],
+    [await orionConfig.getAddress(), await vaultBeacon.getAddress()],
     owner,
   );
 


### PR DESCRIPTION
Drop Ownable from LO, factories, registry, and price adapters; gate privileged writes with onlyAdmin against Config ownership to avoid multi-ownable Safe drift.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Centralized administrative authorization across liquidity, vault, pricing, and factory components through the protocol configuration owner.
  * Updated initialization and deployment flows to use protocol configuration rather than separate owner addresses.
  * Administrative operations, pause controls, fee claims, withdrawals, configuration updates, and upgrades now follow the unified authorization model.
  * Updated unauthorized-access handling and validation for the revised setup.
  * Updated package version to 2.7.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->