### PR TITLE
fix: reserve Ownable ERC-7201 namespaces for UUPS layout compatibility

### DIFF
--- a/contracts/LiquidityOrchestrator.sol
+++ b/contracts/LiquidityOrchestrator.sol
@@ -22,6 +22,7 @@ import "./interfaces/IExecutionAdapter.sol";
 import "@openzeppelin/contracts/interfaces/IERC4626.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/utils/math/SafeCast.sol";
+import { ReservedOwnableNamespaces } from "./utils/ReservedOwnableNamespaces.sol";
 /**
  * @title Liquidity Orchestrator
  * @notice Contract that orchestrates liquidity operations
@@ -37,7 +38,8 @@ contract LiquidityOrchestrator is
     ReentrancyGuardTransient,
     PausableUpgradeable,
     UUPSUpgradeable,
-    ILiquidityOrchestrator
+    ILiquidityOrchestrator,
+    ReservedOwnableNamespaces
 {
     using Math for uint256;
     using SafeERC20 for IERC20;

--- a/contracts/factories/EncryptedVaultFactory.sol
+++ b/contracts/factories/EncryptedVaultFactory.sol
@@ -10,6 +10,7 @@ import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import { ErrorsLib } from "../libraries/ErrorsLib.sol";
 import { EventsLib } from "../libraries/EventsLib.sol";
 import { OrionEncryptedVault } from "../vaults/OrionEncryptedVault.sol";
+import { ReservedOwnableNamespaces } from "../utils/ReservedOwnableNamespaces.sol";
 
 /**
  * @title EncryptedVaultFactory
@@ -18,7 +19,7 @@ import { OrionEncryptedVault } from "../vaults/OrionEncryptedVault.sol";
  * @dev This contract deploys BeaconProxy instances that point to a shared encrypted vault implementation.
  * @custom:security-contact security@orionfinance.ai
  */
-contract EncryptedVaultFactory is Initializable, UUPSUpgradeable {
+contract EncryptedVaultFactory is Initializable, UUPSUpgradeable, ReservedOwnableNamespaces {
     /// @notice Orion Config contract address
     IOrionConfig public config;
 

--- a/contracts/factories/TransparentVaultFactory.sol
+++ b/contracts/factories/TransparentVaultFactory.sol
@@ -10,6 +10,7 @@ import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import { ErrorsLib } from "../libraries/ErrorsLib.sol";
 import { EventsLib } from "../libraries/EventsLib.sol";
 import { OrionTransparentVault } from "../vaults/OrionTransparentVault.sol";
+import { ReservedOwnableNamespaces } from "../utils/ReservedOwnableNamespaces.sol";
 
 /**
  * @title TransparentVaultFactory
@@ -18,7 +19,7 @@ import { OrionTransparentVault } from "../vaults/OrionTransparentVault.sol";
  * @dev This contract deploys BeaconProxy instances that point to a shared transparent vault implementation.
  * @custom:security-contact security@orionfinance.ai
  */
-contract TransparentVaultFactory is Initializable, UUPSUpgradeable {
+contract TransparentVaultFactory is Initializable, UUPSUpgradeable, ReservedOwnableNamespaces {
     /// @notice Orion Config contract address
     IOrionConfig public config;
 

--- a/contracts/price/PriceAdapterRegistry.sol
+++ b/contracts/price/PriceAdapterRegistry.sol
@@ -10,6 +10,7 @@ import { EventsLib } from "../libraries/EventsLib.sol";
 import { UtilitiesLib } from "../libraries/UtilitiesLib.sol";
 import { IOrionConfig } from "../interfaces/IOrionConfig.sol";
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { ReservedOwnableNamespaces } from "../utils/ReservedOwnableNamespaces.sol";
 
 /**
  * @title PriceAdapterRegistry
@@ -18,7 +19,7 @@ import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
  * @dev This contract allows the configuration of price adapters for various assets in the investment universe.
  * @custom:security-contact security@orionfinance.ai
  */
-contract PriceAdapterRegistry is Initializable, IPriceAdapterRegistry, UUPSUpgradeable {
+contract PriceAdapterRegistry is Initializable, IPriceAdapterRegistry, UUPSUpgradeable, ReservedOwnableNamespaces {
     /// @notice Orion Config contract address
     address public configAddress;
 

--- a/contracts/utils/ReservedOwnableNamespaces.sol
+++ b/contracts/utils/ReservedOwnableNamespaces.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.34;
+
+/**
+ * @title ReservedOwnableNamespaces
+ * @notice Reserves OpenZeppelin Ownable / Ownable2Step ERC-7201 storage namespaces.
+ */
+abstract contract ReservedOwnableNamespaces {
+    /// @custom:storage-location erc7201:openzeppelin.storage.Ownable
+    struct OwnableStorage {
+        address _owner;
+    }
+
+    /// @custom:storage-location erc7201:openzeppelin.storage.Ownable2Step
+    struct Ownable2StepStorage {
+        address _pendingOwner;
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orion-finance/protocol",
   "description": "Orion Finance Protocol",
-  "version": "2.7.5",
+  "version": "2.7.6",
   "type": "module",
   "engines": {
     "node": ">=22.13.0"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Updated core liquidity, vault factory, and pricing registry contracts with standardized ownership namespace support.
  - Added reserved storage handling for ownership and pending ownership data to improve upgradeable contract compatibility.

- **Chores**
  - Updated the package version to 2.7.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->